### PR TITLE
Fix Encoding Issue

### DIFF
--- a/lib/tasks/ddb.rake
+++ b/lib/tasks/ddb.rake
@@ -4,9 +4,9 @@ namespace :ddb do
     puts "Creating/Migrating DynamoDB tables..."
     migration = Aws::Record::TableMigration.new(Article)
     migration.create!(
-      provisioned_throughput: {
-        read_capacity_units: 1,
-        write_capacity_units: 1
+      provisioned_throughput: {
+        read_capacity_units: 1,
+        write_capacity_units: 1
       }
     )
 


### PR DESCRIPTION
Was getting an error that the `:provisioned_throughput` parameter did
not exist in `Aws::DynamoDB::Client#create_table`, which is not
correct. Appears to be an encoding issue with the file.